### PR TITLE
Add `aiter_chunks`

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,17 @@
+import turbopipes
+
+
+async def test_aiter_chunks():
+    async def generate(count):
+        for x in range(count):
+            yield x
+
+    actual = []
+    async for chunk in turbopipes.aiter_chunks(generate(13), 5):
+        actual.append(chunk)
+    expected = [
+        list(range(5)),
+        list(range(5, 10)),
+        list(range(10, 13)),
+    ]
+    assert actual == expected

--- a/turbopipes/__init__.py
+++ b/turbopipes/__init__.py
@@ -1,5 +1,7 @@
 from ._aparallel import aparallel
+from ._misc import aiter_chunks
 
 __all__ = [
+    'aiter_chunks',
     'aparallel',
 ]

--- a/turbopipes/_misc.py
+++ b/turbopipes/_misc.py
@@ -1,0 +1,19 @@
+from collections.abc import AsyncIterator
+from typing import TypeVar
+
+_T = TypeVar('_T')
+
+
+async def aiter_chunks(
+    it: AsyncIterator[_T],
+    chunk_size: int,
+) -> AsyncIterator[list[_T]]:
+    """Yields results from an async iterator in chunks of a particular size."""
+    chunk = []
+    async for item in it:
+        chunk.append(item)
+        if len(chunk) == chunk_size:
+            yield chunk
+            chunk = []
+    if chunk:
+        yield chunk


### PR DESCRIPTION
Add simple `aiter_chunks` helper function, which consumes an async iterator and dishes it out in chunks.